### PR TITLE
Change tr invocation in setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can install Abot via Go:
 ```
 $ go get github.com/itsabot/abot
 $ cd $GOPATH/src/github.com/itsabot/abot
-$ cmd/setup.sh
+$ source cmd/setup.sh
 $ abot server
 ```
 

--- a/cmd/setup.sh
+++ b/cmd/setup.sh
@@ -51,7 +51,7 @@ sed -i='' -n '/export ABOT_ENV=/!p' $FILE
 sed -i='' -n '/export ABOT_SECRET=/!p' $FILE
 
 # Generate ABOT_SECRET used for validating cookie values
-SECRET=$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-64};echo;)
+SECRET=$(< /dev/urandom LC_CTYPE=C tr -dc [:alnum:]][}{,.+-_ | head -c${1:-64};echo;)
 
 # Append environment variables
 cat <<EOT >> $FILE


### PR DESCRIPTION
### Preface 

Hi,

First and foremost: Apologies if this isn't the correct workflow for opening a pull request. The contributing page made it seem like this was an appropriate way to make relatively minor contributions, but if there are steps I should've taken first (like posting on the mailing list), I can absolutely do that and close this.

### Update to the `tr` call in the setup script

I'm proposing a couple of changes to the `tr` call in the setup script: One enhancement and one small fix for users trying to run the setup script on OS X (I'm running 10.11.3, but I imagine it affects previous OS X versions as well).

1. Use [:alnum:] instead of enumerating the characters. Also add a small subset of punctuation characters that won't cause horrible problems, but allow a slightly larger universe of characters to create the secret from.

2. Set `LC_CTYPE`. In OS X, at least, `tr` will fail miserably when reading from `/dev/urandom`. I suppose this is probably because `tr` encounters non-UTF sequences in `/dev/urandom` and then bails out. I don't think this change will affect other OSes, but I could certainly wrap this in an `$OSTYPE` check if it eases anyone's mind.

### Update the README

This is explained in the commit, but I think the README should say `source cmd/setup.sh` instead of just `cmd/setup.sh`