### PR TITLE
updates cmd/setup.sh and environment variable loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 client_secret.json
 public/*
 Procfile
+plugins.go
+abot.env


### PR DESCRIPTION
modifications to cmd/setup.sh:
- improves the "postgres running" check
- add checks for go binary, psql binary, and GOPATH
- fixes osx/linux compatibility issues with the urandom/tr command
- makes the terminal output prettier
- exports necessary environment variables to a project local "abot.env" file
  this replaces the previous behavior of inserting the variables into the
  users .bashrc/.bash_profile

modifications to abot.go:
- uses values from the new "abot.env" file to update the environment.
  note: it will only update environment variables that are not already set

modifications to .gitignore:
- adds abot.env: it contains the server secret
- adds plugins.go: it is dynamically generated