### PR TITLE
Update WS endpoint

### DIFF
--- a/assets/html/layout.html
+++ b/assets/html/layout.html
@@ -28,7 +28,7 @@
 		}, delay)
 		at++
 	})();
-})('ws://'+window.location.host+'/_/cmd/ws', 1000);
+})('ws://'+window.location.host+'/ws', 1000);
 </script>
 {{end}}
 </head>


### PR DESCRIPTION
It seems like the intention was to hit "/ws", not "/_/cmd/ws".

Hitting the latter returns errors over and over again (about receiving a
200 code), whereas the former seems to give the correct behavior
(establishes a websocket connection and switches protocols after the initial
request).