### PR TITLE
Return 500s in the event of errors on signup

### DIFF
--- a/core/handlers.go
+++ b/core/handlers.go
@@ -260,17 +260,17 @@ func HAPISignupSubmit(w http.ResponseWriter, r *http.Request) {
 	}
 	err := user.Create(db, dt.FlexIDType(2), req.FID)
 	if err != nil {
-		writeError(w, err)
+		writeErrorInternal(w, err)
 		return
 	}
 	csrfToken, err := createCSRFToken(user)
 	if err != nil {
-		writeError(w, err)
+		writeErrorInternal(w, err)
 		return
 	}
 	header, token, err := getAuthToken(user)
 	if err != nil {
-		writeError(w, err)
+		writeErrorInternal(w, err)
 		return
 	}
 	resp := struct {


### PR DESCRIPTION
If the form validation goes through but there's an error at the database
level, or with creating the CSRF token, then return a 500.

We shouldn't allow the user to proceed, but it's not necessarily the
case that they've entered bad data (e.g. pg server being down would also
cause a failure).

Fixes #18 