### PR TITLE
Allow non-users to message Abot

### DIFF
--- a/core/handlers.go
+++ b/core/handlers.go
@@ -96,7 +96,7 @@ func HIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 // HMain is the endpoint to hit when you want a direct response via JSON.
-// The Abot console (abotc) uses this endpoint.
+// The Abot console uses this endpoint.
 func HMain(w http.ResponseWriter, r *http.Request) {
 	errMsg := "Something went wrong with my wiring... I'll get that fixed up soon."
 	ret, _, err := ProcessText(r)

--- a/db/migrations/down/1460597593_add_flexid_to_messages.sql
+++ b/db/migrations/down/1460597593_add_flexid_to_messages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE messages DROP COLUMN flexidtype;
+ALTER TABLE messages DROP COLUMN flexid;

--- a/db/migrations/up/1460597593_add_flexid_to_messages.sql
+++ b/db/migrations/up/1460597593_add_flexid_to_messages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE messages ADD COLUMN flexid VARCHAR(255);
+ALTER TABLE messages ADD COLUMN flexidtype INTEGER;

--- a/shared/datatypes/conversation.go
+++ b/shared/datatypes/conversation.go
@@ -56,10 +56,11 @@ func (m *Msg) Update(db *sqlx.DB) error {
 // Save a message to the database, updating the message ID.
 func (m *Msg) Save(db *sqlx.DB) error {
 	q := `INSERT INTO messages
-	      (userid, sentence, plugin, route, abotsent, needstraining)
-	      VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`
+	      (userid, sentence, plugin, route, abotsent, needstraining, flexid,
+		flexidtype)
+	      VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING id`
 	row := db.QueryRowx(q, m.User.ID, m.Sentence, m.Plugin, m.Route,
-		m.AbotSent, m.NeedsTraining)
+		m.AbotSent, m.NeedsTraining, m.User.FlexID, m.User.FlexIDType)
 	if err := row.Scan(&m.ID); err != nil {
 		return err
 	}

--- a/shared/task/request_signup.go
+++ b/shared/task/request_signup.go
@@ -1,0 +1,25 @@
+package task
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/itsabot/abot/shared/datatypes"
+)
+
+// requestSignup asks the user to sign up or login via the ABOT_URL/signup.
+func requestSignup(sm *dt.StateMachine, label string) []dt.State {
+	return []dt.State{
+		{
+			OnEntry: func(in *dt.Msg) string {
+				s := os.Getenv("ABOT_URL")
+				return fmt.Sprintf("Please sign up or associate this contact information with your account to continue: %s/signup", s)
+			},
+			OnInput: func(in *dt.Msg) {
+			},
+			Complete: func(in *dt.Msg) (bool, string) {
+				return in.User.Registered(), ""
+			},
+		},
+	}
+}

--- a/shared/task/task.go
+++ b/shared/task/task.go
@@ -18,6 +18,10 @@ const (
 	// that they're authorized to make a purchase. The request is skipped if
 	// the user has authorized by the same or more secure method recently.
 	RequestPurchaseAuthZip
+
+	// RequestSignup requests that a user sign up or add their contact
+	// information via ABOT_URL/signup.
+	RequestSignup
 )
 
 // New returns a slice of States for inclusion into a StateMachine.SetStates()
@@ -28,6 +32,8 @@ func New(sm *dt.StateMachine, t Type, label string) []dt.State {
 		return getAddress(sm, label)
 	case RequestCalendar:
 		return getCalendar(sm, label)
+	case RequestSignup:
+		return requestSignup(sm, label)
 	}
 	return []dt.State{}
 }


### PR DESCRIPTION
This also removes the `ErrMissingUser`, since that's no longer an error. It's now fine to message Abot from an unfamiliar phone number. If a plugin wants to ensure a user signs up before that user reaches some secure point (a banking plugin? shopping?), the plugin can include the `RequestSignup` task in its state machine.

Alternatively, a plugin could enforce logins globally (across all plugins) by registering event listeners to override requests sent by unregistered users.

Everyone will want to run the included migration if they're pulling in this change.