### PR TITLE
Load env variables in tests

### DIFF
--- a/abot_test.go
+++ b/abot_test.go
@@ -6,10 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/itsabot/abot/core"
 	"github.com/itsabot/abot/core/log"
 )
 
 func TestMain(m *testing.M) {
+	if err := core.LoadEnvVars(); err != nil {
+		log.Info("failed to load env vars", err)
+	}
 	if err := os.Setenv("ABOT_ENV", "test"); err != nil {
 		log.Fatal(err)
 	}

--- a/core/handlers_test.go
+++ b/core/handlers_test.go
@@ -18,15 +18,16 @@ import (
 var router *httprouter.Router
 
 func TestMain(m *testing.M) {
+	if err := LoadEnvVars(); err != nil {
+		log.Info("failed to load env vars", err)
+	}
 	if err := os.Setenv("ABOT_ENV", "test"); err != nil {
-		log.Info("failed to set ABOT_ENV", err)
-		os.Exit(1)
+		log.Fatal("failed to set ABOT_ENV", err)
 	}
 	var err error
 	router, err = NewServer()
 	if err != nil {
-		log.Info("failed to start server", err)
-		os.Exit(1)
+		log.Fatal("failed to start server", err)
 	}
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
Fixes tests running locally by loading your abot.env. To keep TravisCI from complaining, it doesn't error out if the abot.env file is missing--it simply logs and continues.