### PR TITLE
Remove plugin_onboard from routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ to your plugin.json like so:
 ```json
 {
 	"Name": "abot",
-	"Version": "0.1.0",
+	"Version": "0.2.0-alpha",
+	"ImportPath": "github.com/itsabot/abot",
 	"Dependencies": {
-		"github.com/itsabot/plugin_onboard": "*",
 		"github.com/itsabot/plugin_weather": "*"
 	}
 }
@@ -78,8 +78,8 @@ Then run the following in your terminal to download the plugins:
 
 ```bash
 $ abot plugin install
-Fetching 2 plugins...
-Installing plugins...
+Fetching 1 plugin...
+Installing plugin...
 Success!
 ```
 

--- a/core/plugin.go
+++ b/core/plugin.go
@@ -84,16 +84,6 @@ func CallPlugin(p *dt.Plugin, in *dt.Msg, followup bool) string {
 // ErrMissingPlugin. The bool value return indicates whether this plugin is
 // different from the last plugin used by the user.
 func GetPlugin(db *sqlx.DB, m *dt.Msg) (*dt.Plugin, string, bool, error) {
-	// First check if the user is missing. AKA, needs to be onboarded
-	if m.User == nil {
-		p := RegPlugins.Get("onboard_onboard")
-		if p == nil {
-			log.Debug("missing required onboard plugin")
-			return nil, "onboard_onboard", false, ErrMissingPlugin
-		}
-		return p, "onboard_onboard", true, nil
-	}
-
 	// First we look for a previously used route. we have to do this in
 	// any case to check if the users pkg/route has changed, so why not now?
 	log.Debug("getting last route")


### PR DESCRIPTION
Update the README and remove references to a no-longer-necessary plugin from the code. Non-users are now able to speak to Abot, and it's up to each plugin to decide whether a login is needed.