### PR TITLE
Fix missing plugins.go bug

### DIFF
--- a/shared/plugin/plugin.go
+++ b/shared/plugin/plugin.go
@@ -44,7 +44,7 @@ func New(url string, trigger *nlp.StructuredInput,
 	// Read plugin.json data from within plugins.go, unmarshal into struct
 	p := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "itsabot",
 		"abot", "plugins.go")
-	fi, err := os.Open(p)
+	fi, err := os.OpenFile(p, os.O_RDONLY|os.O_CREATE, 0666)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This fixes a bug that occasionally prevents `abot p install` and other commands from running when the generated `plugins.go` is missing.