### PR TITLE
Add settings API

### DIFF
--- a/abot.go
+++ b/abot.go
@@ -40,9 +40,6 @@ type ErrMessage struct {
 func main() {
 	rand.Seed(time.Now().UnixNano())
 	log.SetDebug(os.Getenv("ABOT_DEBUG") == "true")
-	if err := core.LoadEnvVars(); err != nil {
-		log.Fatal(err)
-	}
 	app := cli.NewApp()
 	app.Commands = []cli.Command{
 		{

--- a/assets/css/form.css
+++ b/assets/css/form.css
@@ -10,3 +10,6 @@
 .form-header {
 	margin: 0 0 0.5em 0;
 }
+.form-align label {
+	margin-right: 1em;
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -140,6 +140,7 @@ window.addEventListener('load', function() {
 		"/response_panel/conversation": abot.ResponsePanelConversation,
 		"/manage_team": abot.ManageTeam,
 		"/account_connect": abot.AccountConnect,
+		"/settings": abot.Settings,
 		"/:any...": abot.NotFound,
 	})
 })

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,126 @@
+(function(abot) {
+abot.Settings = {}
+abot.Settings.controller = function() {
+	var ctrl = this
+	ctrl.save = function() {
+		var changed = document.querySelectorAll(".input-changed")
+		if (changed.length === 0) {
+			return
+		}
+		var data = {}
+		var ps = ctrl.props.plugins()
+		for (var i = 0; i < ps.length; ++i) {
+			var p = ps[i]
+			if (p.Settings == null) {
+				continue
+			}
+			data[p.Name] = {}
+			Object.keys(p.Settings).map(function(settingName) {
+				data[p.Name][settingName] = p.Settings[settingName] || ""
+			})
+		}
+		abot.request({
+			url: "/api/admin/settings.json",
+			method: "PUT",
+			data: data,
+		}).then(function(resp) {
+			ctrl.props.error("")
+			ctrl.props.success("Success! Saved changes.")
+			for (var i = 0; i < changed.length; ++i) {
+				changed[i].classList.remove("input-changed")
+			}
+		}, function(err) {
+			ctrl.props.success("")
+			ctrl.props.error(err.Msg)
+		})
+	}
+	ctrl.markChanged = function(val) {
+		this.classList.add("input-changed")
+		var pluginIdx = this.getAttribute("data-plugin-idx")
+		var setting = this.getAttribute("data-setting")
+		ctrl.props.plugins()[pluginIdx].Settings[setting] = val
+	}
+	ctrl.discard = function() {
+		if (document.querySelector(".input-changed") == null) {
+			return
+		}
+		if (confirm("Are you sure you want to discard your changes?")) {
+			m.route(window.location.pathname, null, true)
+		}
+	}
+	ctrl.props = {
+		plugins: m.prop([]),
+		error: m.prop(""),
+		success: m.prop(""),
+	}
+	abot.Plugins.fetch().then(function(resp) {
+		ctrl.props.plugins(resp || [])
+	}, function(err) {
+		ctrl.props.error(err.Msg)
+	})
+}
+abot.Settings.view = function(ctrl) {
+	return m(".body", [
+		m.component(abot.Header),
+		m(".container", [
+			m.component(abot.Sidebar, { active: 5 }),
+			m(".main", [
+				m(".topbar", "Settings"),
+				m(".content", [
+					function() {
+						if (ctrl.props.error().length > 0) {
+							return m(".alert.alert-danger.alert-margin", ctrl.props.error())
+						}
+						if (ctrl.props.success().length > 0) {
+							return m(".alert.alert-success.alert-margin", ctrl.props.success())
+						}
+					}(),
+					function() {
+						if (ctrl.props.plugins().length === 0) {
+							return m("p.top-el", "No plugins installed.")
+						}
+						return ctrl.props.plugins().map(function(plugin, i) {
+							var title
+							if (i === 0) {
+								title = m("h3.top-el", plugin.Name)
+							} else {
+								title = m("h3", plugin.Name)
+							}
+							var ss = []
+							Object.keys(plugin.Settings).map(function(setting) {
+								ss.push(m("tr", [
+									m("td", [
+										m("label", setting),
+									]),
+									m("td", [
+										m("input[type=text]", {
+											oninput: m.withAttr("value", ctrl.markChanged),
+											"data-plugin-idx": i,
+											"data-setting": setting,
+											value: plugin.Settings[setting],
+										}),
+									]),
+								]))
+							})
+							return m("form.form-align", [
+								title,
+								m("table", [ ss ]),
+							])
+						})
+					}(),
+					m("#btns.btn-container-left", [
+						m("input[type=button].btn", {
+							onclick: ctrl.discard,
+							value: "Discard Changes",
+						}),
+						m("input[type=button].btn.btn-primary", {
+							onclick: ctrl.save,
+							value: "Save",
+						}),
+					]),
+				]),
+			]),
+		]),
+	])
+}
+})(!window.abot ? window.abot={} : window.abot);

--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -33,6 +33,12 @@ abot.Sidebar.view = function(_, args) {
 				active: args.active === 4,
 				icon: "link.svg",
 			}),
+			m.component(abot.SidebarItem, {
+				href: "/settings",
+				text: "Settings",
+				active: args.active === 5,
+				icon: "settings.svg",
+			}),
 		]),
 	])
 }

--- a/db/migrations/down/1465921896_create_settings.sql
+++ b/db/migrations/down/1465921896_create_settings.sql
@@ -1,0 +1,1 @@
+DROP TABLE settings;

--- a/db/migrations/up/1465921896_create_settings.sql
+++ b/db/migrations/up/1465921896_create_settings.sql
@@ -1,0 +1,6 @@
+CREATE TABLE settings (
+	name VARCHAR(255) NOT NULL,
+	value VARCHAR(255) NOT NULL,
+	pluginname VARCHAR(255) NOT NULL,
+	PRIMARY KEY (pluginname, name)
+);

--- a/shared/datatypes/plugin.go
+++ b/shared/datatypes/plugin.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/itsabot/abot/core/log"
@@ -40,6 +41,17 @@ type PluginConfig struct {
 	// ID is the remote ID of the plugin. This is pulled automatically at
 	// time of plugin install from ITSABOT_URL.
 	ID uint64
+
+	// Settings is a collection of options for use by a plugin, such as a
+	// required API key.
+	Settings map[string]*PluginSetting
+}
+
+// PluginSetting defines whether a plugin's setting is required (empty values
+// panic on boot), and whether there's a default value.
+type PluginSetting struct {
+	Required bool
+	Default  string
 }
 
 // PluginEvents allow plugins to listen to events as they happen in Abot core.
@@ -213,6 +225,28 @@ func (p *Plugin) DeleteMemory(in *Msg, k string) {
 		p.Log.Infof("could not delete memory for key %s. %s", k,
 			err.Error())
 	}
+}
+
+// GetSetting retrieves a specific setting's value. It throws a fatal error if
+// the setting has not been declared in the plugin's plugin.json file.
+func (p *Plugin) GetSetting(name string) string {
+	if p.Config.Settings[name] == nil {
+		m := fmt.Sprintf(
+			"missing setting %s. please declare it in the %s's plugin.json",
+			name, p.Config.Name)
+		log.Fatal(m)
+	}
+	var val string
+	q := `SELECT value FROM settings WHERE name=$1 AND pluginname=$2`
+	err := p.DB.Get(&val, q, name, p.Config.Name)
+	if err == sql.ErrNoRows {
+		return p.Config.Settings[name].Default
+	}
+	if err != nil {
+		log.Info("failed to get plugin setting.", err)
+		return ""
+	}
+	return val
 }
 
 // HasMemory is a helper function to simply a common use-case, determing if some

--- a/shared/task/iterate.go
+++ b/shared/task/iterate.go
@@ -34,6 +34,9 @@ func Iterate(p *dt.Plugin, label string, opts OptsIterate) []dt.State {
 			OnEntry: func(in *dt.Msg) string {
 				var ss []string
 				mem := p.GetMemory(in, opts.IterableMemKey)
+				if len(mem.Val) == 0 {
+					mem.Val = []byte(`[]`)
+				}
 				err := json.Unmarshal(mem.Val, &ss)
 				if err != nil {
 					p.Log.Info("failed to get iterable memory.", err)


### PR DESCRIPTION
To make plugin installation easier, environment variables that plugins depend upon have been moved to a specific Settings API. Instead of using `os.Getenv`, plugins must now use `p.GetSetting()`. Those settings must also be declared in your plugin.json per the updated spec: https://github.com/itsabot/abot/wiki/plugin.json-Spec

With this change, you'll be able to edit plugin-specific variables via the admin panel (like API keys), and itsabot.org can provide more helpful (and complete) install instructions.